### PR TITLE
Expose deparseSync

### DIFF
--- a/queryparser.cc
+++ b/queryparser.cc
@@ -123,10 +123,6 @@ void Method(const FunctionCallbackInfo<Value>& args) {
 
 void MethodDeparse(const FunctionCallbackInfo<Value>& args) {
     Isolate* isolate = args.GetIsolate();
-    JSON::Parse(
-            isolate,
-            String::NewFromUtf8(isolate, result.plpgsql_funcs)
-        ).ToLocal(&parseResult);
     String::Utf8Value parse_tree(args[0]->ToString());
     PgQueryDeparseResult result = pg_query_deparse_protobuf(*parse_tree);
     args.GetReturnValue().Set(QueryDeparseResponse(isolate, result));

--- a/script/buildAddon.sh
+++ b/script/buildAddon.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-commit=1ada550d901ed4edbfb6bce2163d21f4b948ab2d
+commit=fc5775e0622955f9e5d887dfaf0b7bbf7f9046f9
 
 rDIR=$(pwd)
 tmpDir=$(mktemp -d 2>/dev/null || mktemp -d -t 'tmpdir.XXXX')

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -5,6 +5,11 @@
 // Expose synchronous and asynchronous access to our parsing functions
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set(
+    Napi::String::New(env, "deparseQuerySync"),
+    Napi::Function::New(env, DeparseQuerySync)
+  );
+
+  exports.Set(
     Napi::String::New(env, "parseQuerySync"),
     Napi::Function::New(env, ParseQuerySync)
   );

--- a/src/helpers.cc
+++ b/src/helpers.cc
@@ -14,6 +14,19 @@ Napi::Error CreateError(Napi::Env env, const PgQueryError& err)
     return error;
 }
 
+Napi::String QueryDeparseResult(Napi::Env env, const PgQueryDeparseResult& result)
+{
+    if (result.error) {
+        auto throwVal = CreateError(env, *result.error);
+        pg_query_free_deparse_result(result);
+        throw throwVal;
+    }
+
+    auto returnVal = Napi::String::New(env, result.query);
+    pg_query_free_deparse_result(result);
+    return returnVal;
+}
+
 Napi::String QueryParseResult(Napi::Env env, const PgQueryParseResult& result)
 {
     if (result.error) {

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -2,6 +2,7 @@
 #include <napi.h>
 
 Napi::Error CreateError(Napi::Env env, const PgQueryError& err);
+Napi::String QueryDeparseResult(Napi::Env env, const PgQueryDeparseResult& result);
 Napi::String QueryParseResult(Napi::Env env, const PgQueryParseResult& result);
 Napi::String PlPgSQLParseResult(Napi::Env env, const PgQueryPlpgsqlParseResult& result);
 Napi::String FingerprintResult(Napi::Env env, const PgQueryFingerprintResult & result);

--- a/src/sync.cc
+++ b/src/sync.cc
@@ -3,6 +3,13 @@
 #include "sync.h"  // NOLINT(build/include)
 #include "helpers.h"  // NOLINT(build/include)
 
+Napi::String DeparseQuerySync(const Napi::CallbackInfo& info) {
+  std::string parse_tree = info[0].As<Napi::String>();
+  PgQueryDeparseResult result = pg_query_deparse_protobuf(parse_tree.c_str());
+
+  return QueryDeparseResult(info.Env(), result);
+}
+
 Napi::String ParseQuerySync(const Napi::CallbackInfo& info) {
   std::string query = info[0].As<Napi::String>();
   PgQueryParseResult result = pg_query_parse(query.c_str());

--- a/src/sync.h
+++ b/src/sync.h
@@ -1,5 +1,6 @@
 #include <napi.h>
 
+Napi::String DeparseQuerySync(const Napi::CallbackInfo& info);
 Napi::String ParseQuerySync(const Napi::CallbackInfo& info);
 Napi::String ParsePlPgSQLSync(const Napi::CallbackInfo& info);
 Napi::String FingerprintSync(const Napi::CallbackInfo& info);


### PR DESCRIPTION
Hello 👋,

I'm attempting to expose the `pg_query_deparse_protobuf` function.

I tried to follow the existing code, but I don't have any experience with C++ or NAPI so I'm stuck on the `DeparseQuerySync` function in `sync.cc`. 😅

I understand that `pg_query_deparse_protobuf` is expecting the struct `PgQueryProtobuf` as its 1st argument, but I'm not sure how to declare and pass it.

Right now it generates this error:

```sh
../src/sync.cc:8:33: error: no matching function for call to 'pg_query_deparse_protobuf'
  PgQueryDeparseResult result = pg_query_deparse_protobuf(parse_tree.c_str());
                                ^~~~~~~~~~~~~~~~~~~~~~~~~
../libpg_query/include/pg_query.h:95:22: note: candidate function not viable: no known conversion from 'const std::basic_string<char>::value_type *' (aka 'const char *') to 'PgQueryProtobuf' for 1st argument
PgQueryDeparseResult pg_query_deparse_protobuf(PgQueryProtobuf parse_tree);
```

Any help is appreciated. 🙏 

**EDIT**:

In fact, it seems like `pg_query_deparse_protobuf` will only be able to accept the result of `pg_query_parse_protobuf`, so it won't work on the result of `pg_query_parse` if I understand correctly. 🤔
We would need to add a `pg_query_deparse` to [libpg_query](https://github.com/pganalyze/libpg_query) which would accept the result of `pg_query_parse` and skip the protobuf layer. I opened an issue about it: https://github.com/pganalyze/libpg_query/issues/178.

I would love to have your feedback @pyramation on this matter, I saw you opened an issue about deparsing in libpg_query and you were interested in bringing it into this lib. 😄 