### PR TITLE
feat: support windows binary build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,14 +8,6 @@
         "src/sync.cc",
         "src/async.cc"
       ],
-      "actions": [
-        {
-          "outputs": ['libpg_query/include/pg_query.h'],
-          "inputs": [],
-          "action": ['script/buildAddon.sh'],
-          "action_name": 'prebuild_dependencies'
-        }
-      ],
       'cflags!': [ '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],
       'include_dirs': [
@@ -25,7 +17,15 @@
       'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
       'conditions': [
         ['OS=="linux"', {
-          "libraries": [ "-L<!(pwd)/libpg_query/linux", "-lpg_query" ]
+          "libraries": [ "-L<!(pwd)/libpg_query/linux", "-lpg_query" ],
+          "actions": [
+            {
+              "outputs": ['libpg_query/include/pg_query.h'],
+              "inputs": [],
+              "action": ['script/buildAddon.sh'],
+              "action_name": 'prebuild_dependencies'
+            }
+          ],
         }],
         ['OS=="mac"', {
           "libraries": [ "-L<!(pwd)/libpg_query/osx", "-lpg_query" ],
@@ -33,14 +33,42 @@
             "CLANG_CXX_LIBRARY": "libc++",
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
             'MACOSX_DEPLOYMENT_TARGET': '10.7'
-          }
+          },
+          "actions": [
+            {
+              "outputs": ['libpg_query/include/pg_query.h'],
+              "inputs": [],
+              "action": ['script/buildAddon.sh'],
+              "action_name": 'prebuild_dependencies'
+            }
+          ],
         }],
         ['OS=="win"', {
+          "link_settings": {
+            "library_dirs": [
+              "../libpg_query/windows"
+            ],
+            "libraries": [
+              "../libpg_query/windows/pg_query.lib"
+            ],
+          },
           "msvs_settings": {
             "VCCLCompilerTool": {
-              "ExceptionHandling": 1
+              "ExceptionHandling": 0,
+              "AdditionalOptions": ["/EHsc"]
             }
-          }
+          },
+          "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ],
+          "actions":[
+            {
+              "outputs": [
+                ""
+              ],
+              "inputs": [],
+              "action": ['../script/buildAddon.bat'],
+              "action_name": 'prebuild_dependencies'
+            }
+          ]
         }]
       ]
     }

--- a/script/buildAddon.bat
+++ b/script/buildAddon.bat
@@ -1,0 +1,68 @@
+@echo off
+
+set commit=1ec38940e5c6f09a4c1d17a46d839a881c4f2db7
+set branch=16-latest
+
+setlocal enabledelayedexpansion
+
+rem Remember current's parent directory and create a new, unique, temporary directory
+set buildDir=%cd%
+set projectDir=%cd%\..
+set tmpDir=%temp%\tmpdir.libpg_query
+rmdir /s /q %tmpDir%
+md %tmpDir%
+
+
+rem Define the make target
+set makeTarget=build
+
+rem Change to the newly created temp directory
+cd /D %tmpDir%
+
+
+rem Clone the selected branch of the libpg_query Git repo
+git clone -b %branch% --single-branch https://github.com/pganalyze/libpg_query.git
+cd libpg_query
+
+rem Checkout the desired commit
+git checkout %commit%
+
+rem needed if being invoked from within gyp
+set MAKEFLAGS=
+set MFLAGS=
+
+rem set path with Windows Developer Command Prompt
+echo "please ensure you are running at Windows Developer Command Prompt environments"
+nmake /F Makefile.msvc clean
+nmake /F Makefile.msvc build
+
+
+rem Terminate if build fails
+if %errorlevel% NEQ 0 (
+    echo ERROR: 'nmake' command failed
+)
+
+rem Search for pg_query.obj (libpg_query.a), error if not found
+for /f "delims=" %%f in ('dir /b /s pg_query.lib') do set file=%%f
+if not defined file (
+    echo "ERROR: pg_query.lib not found"
+
+)
+
+rem Error if pg_query.h is missing
+for /f "delims=" %%f in ('dir /b /s pg_query.h') do set file=%%f
+if not defined file (
+    echo "ERROR: pg_query.h not found"
+
+)
+
+rem Copy pg_query.lib to windows dir
+copy /Y pg_query.lib "%projectDir%\libpg_query\windows\"
+
+rem Copy header
+copy /Y pg_query.h "%projectDir%\libpg_query\include\"
+
+rem Cleanup: revert to original directory
+cd /D %buildDir%
+
+exit /B 0


### PR DESCRIPTION
# feature: support windows build

related Issues #44 #22 


## file changes

- add an .bat script for exuecuting git clone, execute `nmake` build command, and copy built `pg_query.lib` `pg_query.h` to including lib dir
- update binding.gyp, split prebuild_dependencis action to spec os. on windows we spec an action to run `script/buildAddons.bat`


## references

> I am new to build napi addons, so some compile options was copied from below ref issues, pls feel free to advice

1. binding.gyp build options/compile options related link 
  1.1. https://github.com/pganalyze/libpg_query?tab=readme-ov-file#installation
  1.2. https://github.com/nodejs/node-gyp/issues/26#issuecomment-597687271


2. `nmake` required `Visual Studio Developer Command Prompt` in the path env. 
   which means users should run install script at `Visual Studio Developer Command Prompt` at the first time.



below is my local build log

gyp build log
```
$ npm run binary:build > build.log
node-pre-gyp info it worked if it ends with ok
node-pre-gyp info using node-pre-gyp@1.0.11
node-pre-gyp info using node@18.19.1 | win32 | x64
gyp info it worked if it ends with ok
gyp info using node-gyp@10.0.1
gyp info using node@18.19.1 | win32 | x64
gyp info ok
gyp info it worked if it ends with ok
gyp info using node-gyp@10.0.1
gyp info using node@18.19.1 | win32 | x64
gyp info find Python using Python version 3.12.2 found at "C:\Users\Jason\scoop\apps\python\current\python.exe"
gyp info find VS using VS2022 (17.9.34701.34) found at:
gyp info find VS "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools"
gyp info find VS run with --verbose for detailed information
gyp info spawn C:\Users\Jason\scoop\apps\python\current\python.exe
gyp info spawn args [
gyp info spawn args 'C:\\Users\\Jason\\scoop\\persist\\nvm\\nodejs\\v18.19.1\\node_modules\\npm\\node_modules\\node-gyp\\gyp\\gyp_main.py',
gyp info spawn args 'binding.gyp',
gyp info spawn args '-f',
gyp info spawn args 'msvs',
gyp info spawn args '-I',
gyp info spawn args 'C:\\Users\\Jason\\Repos\\Study\\libpg-query-node\\build\\config.gypi',
gyp info spawn args '-I',
gyp info spawn args 'C:\\Users\\Jason\\scoop\\persist\\nvm\\nodejs\\v18.19.1\\node_modules\\npm\\node_modules\\node-gyp\\addon.gypi',
gyp info spawn args '-I',
gyp info spawn args 'C:\\Users\\Jason\\AppData\\Local\\node-gyp\\Cache\\18.19.1\\include\\node\\common.gypi',
gyp info spawn args '-Dlibrary=shared_library',
gyp info spawn args '-Dvisibility=default',
gyp info spawn args '-Dnode_root_dir=C:\\Users\\Jason\\AppData\\Local\\node-gyp\\Cache\\18.19.1',
gyp info spawn args '-Dnode_gyp_dir=C:\\Users\\Jason\\scoop\\persist\\nvm\\nodejs\\v18.19.1\\node_modules\\npm\\node_modules\\node-gyp',
gyp info spawn args '-Dnode_lib_file=C:\\\\Users\\\\Jason\\\\AppData\\\\Local\\\\node-gyp\\\\Cache\\\\18.19.1\\\\<(target_arch)\\\\node.lib',
gyp info spawn args '-Dmodule_root_dir=C:\\Users\\Jason\\Repos\\Study\\libpg-query-node',
gyp info spawn args '-Dnode_engine=v8',
gyp info spawn args '--depth=.',
gyp info spawn args '--no-parallel',
gyp info spawn args '--generator-output',
gyp info spawn args 'C:\\Users\\Jason\\Repos\\Study\\libpg-query-node\\build',
gyp info spawn args '-Goutput_dir=.'
gyp info spawn args ]
←[37;40mgyp←[0m ←[32minfo←[0m ←[35mok←[0m
gyp info it worked if it ends with ok
gyp info using node-gyp@10.0.1
gyp info using node@18.19.1 | win32 | x64
gyp info spawn C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe
gyp info spawn args [
gyp info spawn args 'build\\binding.sln',
gyp info spawn args '/clp:Verbosity=minimal',
gyp info spawn args '/nologo',
gyp info spawn args '/p:Configuration=Release;Platform=x64'
gyp info spawn args ]
gyp info ok
node-pre-gyp info package Binary staged at "build\stage\libpg-query-node\queryparser-v16.0.1-node-v108-win32-x64.tar.gz"
node-pre-gyp info ok
```

pg_query windows build log

```

> libpg-query@16.0.1 binary:build
> node-pre-gyp rebuild package

[libpg-query] Removing "C:\Users\Jason\Repos\Study\libpg-query-node\build\Release"


  nothing.vcxproj -> C:\Users\Jason\Repos\Study\libpg-query-node\build\Release\\nothing.lib
  prebuild_dependencies
  Cloning into 'libpg_query'...
  Note: switching to '1ec38940e5c6f09a4c1d17a46d839a881c4f2db7'.
  
  You are in 'detached HEAD' state. You can look around, make experimental
  changes and commit them, and you can discard any commits you make in this
  state without impacting any branches by switching back to a branch.
  
  If you want to create a new branch to retain commits you create, you may
  do so (now or later) by using -c with the switch command. Example:
  
    git switch -c <new-branch-name>
  
  Or undo this operation with:
  
    git switch -
  
  Turn off this advice by setting config variable advice.detachedHead to false
  
  HEAD is now at 1ec3894 Release 16-5.1.0
  "please ensure you are running at Windows Developer Command Prompt environments"
  
  Microsoft (R) Program Maintenance Utility Version 14.39.33522.0
  Copyright (C) Microsoft Corporation.  All rights reserved.
  
  	del *.obj
  Could Not Find C:\Users\Jason\AppData\Local\Temp\tmpdir.libpg_query\libpg_query\*.obj
  	del pg_query.lib
  Could Not Find C:\Users\Jason\AppData\Local\Temp\tmpdir.libpg_query\libpg_query\pg_query.lib
  
  Microsoft (R) Program Maintenance Utility Version 14.39.33522.0
  Copyright (C) Microsoft Corporation.  All rights reserved.
  
  	del *.obj
  Could Not Find C:\Users\Jason\AppData\Local\Temp\tmpdir.libpg_query\libpg_query\*.obj
  	del pg_query.lib
  Could Not Find C:\Users\Jason\AppData\Local\Temp\tmpdir.libpg_query\libpg_query\pg_query.lib
  	cl -I. -I./vendor -I./src/postgres/include -I./src/include -I./src/postgres/include/port/win32 -I./src/postgres/include/port/win32_msvc /c src/*.c src/postgres/*.c vendor/protobuf-c/protobuf-c.c vendor/xxhash/xxhash.c protobuf/pg_query.pb-c.c
  Microsoft (R) C/C++ Optimizing Compiler Version 19.39.33522 for x64
  Copyright (C) Microsoft Corporation.  All rights reserved.
  
  pg_query.c
  pg_query_deparse.c
  pg_query_fingerprint.c
  pg_query_json_plpgsql.c
  pg_query_normalize.c
  pg_query_outfuncs_json.c
  pg_query_outfuncs_protobuf.c
  pg_query_parse.c
  pg_query_parse_plpgsql.c
  pg_query_readfuncs_protobuf.c
  pg_query_scan.c
  pg_query_split.c
  postgres_deparse.c
  src_backend_catalog_namespace.c
  src_backend_catalog_pg_proc.c
  src_backend_commands_define.c
  src_backend_nodes_bitmapset.c
  src_backend_nodes_copyfuncs.c
  src_backend_nodes_equalfuncs.c
  src_backend_nodes_extensible.c
  Generating Code...
C:\Users\Jason\AppData\Local\Temp\tmpdir.libpg_query\libpg_query\src\pg_query_readfuncs_protobuf.c(153): warning C4715: '_readNode': not all control paths return a value [C:\Users\Jason\Repos\Study\libpg-query-node\build\queryparser.vcxproj]
  Compiling...
  src_backend_nodes_list.c
  src_backend_nodes_makefuncs.c
  src_backend_nodes_nodeFuncs.c
  src_backend_nodes_nodes.c
  src_backend_nodes_value.c
  src_backend_parser_gram.c
  src_backend_parser_parser.c
  src_backend_parser_scan.c
  src_backend_parser_scansup.c
  src_backend_storage_ipc_ipc.c
  src_backend_tcop_postgres.c
  src_backend_utils_activity_pgstat_database.c
  src_backend_utils_adt_datum.c
  src_backend_utils_adt_expandeddatum.c
  src_backend_utils_adt_format_type.c
  src_backend_utils_adt_numutils.c
  src_backend_utils_adt_ruleutils.c
  src_backend_utils_error_assert.c
  src_backend_utils_error_elog.c
  src_backend_utils_fmgr_fmgr.c
  Generating Code...
  Compiling...
  src_backend_utils_init_globals.c
  src_backend_utils_mb_mbutils.c
  src_backend_utils_misc_guc_tables.c
  src_backend_utils_mmgr_alignedalloc.c
  src_backend_utils_mmgr_aset.c
  src_backend_utils_mmgr_generation.c
  src_backend_utils_mmgr_mcxt.c
  src_backend_utils_mmgr_slab.c
  src_common_encnames.c
  src_common_hashfn.c
  src_common_keywords.c
  src_common_kwlookup.c
  src_common_psprintf.c
  src_common_stringinfo.c
  src_common_wchar.c
  src_pl_plpgsql_src_pl_comp.c
  src_pl_plpgsql_src_pl_funcs.c
  src_pl_plpgsql_src_pl_gram.c
  src_pl_plpgsql_src_pl_handler.c
  src_pl_plpgsql_src_pl_scanner.c
  Generating Code...
  Compiling...
  src_port_pgstrcasecmp.c
  src_port_pg_bitutils.c
  src_port_qsort.c
  src_port_snprintf.c
  src_port_strerror.c
  src_port_strlcpy.c
  protobuf-c.c
  xxhash.c
  pg_query.pb-c.c
  Generating Code...
  	lib /OUT:pg_query.lib *.obj
  Microsoft (R) Library Manager Version 14.39.33522.0
  Copyright (C) Microsoft Corporation.  All rights reserved.
  
          1 file(s) copied.
          1 file(s) copied.
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(254,5): warning MSB8065: Custom build for item "..\binding.gyp" succeeded, but specified output "c:\users\jason\repos\study\libpg-query-node\build" has not been created. This may cause incremental build to work incorrectly. [C:\Users\Jason\Repos\Study\libpg-query-node\build\queryparser.vcxproj]
  addon.cc
  helpers.cc
  sync.cc
  async.cc
  win_delay_load_hook.cc
     Creating library C:\Users\Jason\Repos\Study\libpg-query-node\build\Release\queryparser.lib and object C:\Users\Jason\Repos\Study\libpg-query-node\build\Release\queryparser.exp
  Generating code
  Previous IPDB not found, fall back to full compilation.
  All 286 functions were compiled because no usable IPDB/IOBJ from previous compilation was found.
  Finished generating code
  queryparser.vcxproj -> C:\Users\Jason\Repos\Study\libpg-query-node\build\Release\\queryparser.node
packing Release\nothing.lib
packing Release\obj\queryparser\queryparser.node.recipe
packing Release\obj\queryparser\queryparser.tlog\CL.command.1.tlog
packing Release\obj\queryparser\queryparser.tlog\Cl.items.tlog
packing Release\obj\queryparser\queryparser.tlog\CL.read.1.tlog
packing Release\obj\queryparser\queryparser.tlog\CL.write.1.tlog
packing Release\obj\queryparser\queryparser.tlog\CustomBuild.command.1.tlog
packing Release\obj\queryparser\queryparser.tlog\CustomBuild.read.1.tlog
packing Release\obj\queryparser\queryparser.tlog\CustomBuild.write.1.tlog
packing Release\obj\queryparser\queryparser.tlog\link.command.1.tlog
packing Release\obj\queryparser\queryparser.tlog\link.read.1.tlog
packing Release\obj\queryparser\queryparser.tlog\link.secondary.1.tlog
packing Release\obj\queryparser\queryparser.tlog\link.write.1.tlog
packing Release\obj\queryparser\queryparser.tlog\queryparser.lastbuildstate
packing Release\obj\queryparser\src\addon.obj
packing Release\obj\queryparser\src\async.obj
packing Release\obj\queryparser\src\helpers.obj
packing Release\obj\queryparser\src\sync.obj
packing Release\obj\queryparser\win_delay_load_hook.obj
packing Release\queryparser.exp
packing Release\queryparser.iobj
packing Release\queryparser.ipdb
packing Release\queryparser.lib
packing Release\queryparser.node
packing Release\queryparser.pdb

```



