### PR TITLE
Deparse

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -12,12 +12,18 @@
       'cflags_cc!': [ '-fno-exceptions' ],
       'include_dirs': [
         "libpg_query/include",
-        "<!@(node -p \"require('node-addon-api').include\")"
+        "<!@(node -p \"require('node-addon-api').include\")",
+        "<!(pkg-config --cflags-only-I protobuf | sed 's/-I//g')"
       ],
       'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
       'conditions': [
         ['OS=="linux"', {
-          "libraries": [ "-L<!(pwd)/libpg_query/linux", "-lpg_query" ],
+          "libraries": [
+            "-L<!(pwd)/libpg_query/linux",
+            "-lpg_query",
+            "<!(pkg-config --libs-only-L protobuf)",
+            "<!(pkg-config --libs-only-l protobuf)"
+          ],
           "actions": [
             {
               "outputs": ['libpg_query/include/pg_query.h'],
@@ -28,7 +34,12 @@
           ],
         }],
         ['OS=="mac"', {
-          "libraries": [ "-L<!(pwd)/libpg_query/osx", "-lpg_query" ],
+          "libraries": [
+            "-L<!(pwd)/libpg_query/osx",
+            "-lpg_query",
+            "<!(pkg-config --libs-only-L protobuf)",
+            "<!(pkg-config --libs-only-l protobuf)"
+          ],
           "xcode_settings": {
             "CLANG_CXX_LIBRARY": "libc++",
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',

--- a/index.js
+++ b/index.js
@@ -9,6 +9,14 @@ module.exports = {
     });
   },
 
+  deparseQuery(ast) {
+    return new Promise((resolve, reject) => {
+      PgQuery.deparseQueryAsync(JSON.stringify(ast), (err, result) => {
+        err ? reject(err) : resolve(result);
+      });
+    });
+  },
+
   parsePlPgSQL(query) {
     return new Promise((resolve, reject) => {
       PgQuery.parsePlPgSQLAsync(query, (err, result) => {
@@ -19,6 +27,10 @@ module.exports = {
 
   parseQuerySync(query) {
     return JSON.parse(PgQuery.parseQuerySync(query));
+  },
+
+  deparseQuerySync(ast) {
+    return PgQuery.deparseQuerySync(JSON.stringify(ast));
   },
 
   parsePlPgSQLSync(query) {

--- a/script/buildAddon.sh
+++ b/script/buildAddon.sh
@@ -27,7 +27,7 @@ unset MFLAGS
 
 # Adaptively build for macOS or Linux
 if [ "$(uname)" == "Darwin" ]; then
-	make CFLAGS='-mmacosx-version-min=10.7' PG_CFLAGS='-mmacosx-version-min=10.7' $makeTarget
+	make CFLAGS='-mmacosx-version-min=10.7' PG_CFLAGS='-mmacosx-version-min=10.7' USE_PROTOBUF_CPP=1 $makeTarget
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
 	make CFLAGS='' PG_CFLAGS='' $makeTarget
 fi
@@ -61,6 +61,7 @@ fi
 
 # Copy header
 cp $(pwd)/pg_query.h $rDIR/libpg_query/include/
+cp $(pwd)/protobuf/pg_query.pb.h $rDIR/libpg_query/include/protobuf
 
 # Cleanup: revert to original directory and remove the temp
 cd "$rDIR"

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -15,6 +15,16 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
   );
 
   exports.Set(
+    Napi::String::New(env, "deparseQuerySync"),
+    Napi::Function::New(env, DeparseQuerySync)
+  );
+
+  exports.Set(
+    Napi::String::New(env, "deparseQueryAsync"),
+    Napi::Function::New(env, DeparseQueryAsync)
+  );
+
+  exports.Set(
     Napi::String::New(env, "parsePlPgSQLSync"),
     Napi::Function::New(env, ParsePlPgSQLSync)
   );

--- a/src/async.h
+++ b/src/async.h
@@ -1,5 +1,6 @@
 #include <napi.h>
 
 Napi::Value ParseQueryAsync(const Napi::CallbackInfo& info);
+Napi::Value DeparseQueryAsync(const Napi::CallbackInfo& info);
 Napi::Value ParsePlPgSQLAsync(const Napi::CallbackInfo& info);
 Napi::Value FingerprintAsync(const Napi::CallbackInfo& info);

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -3,5 +3,13 @@
 
 Napi::Error CreateError(Napi::Env env, const PgQueryError& err);
 Napi::String QueryParseResult(Napi::Env env, const PgQueryParseResult& result);
+Napi::String QueryDeparseResult(Napi::Env env, const PgQueryDeparseResult& result);
 Napi::String PlPgSQLParseResult(Napi::Env env, const PgQueryPlpgsqlParseResult& result);
 Napi::String FingerprintResult(Napi::Env env, const PgQueryFingerprintResult & result);
+
+typedef struct {
+  PgQueryProtobuf protobuf;
+  PgQueryError* error;
+} JsonToProtobufResult;
+
+JsonToProtobufResult json_to_protobuf_parse_result(const std::string& json);

--- a/src/sync.cc
+++ b/src/sync.cc
@@ -10,6 +10,21 @@ Napi::String ParseQuerySync(const Napi::CallbackInfo& info) {
   return QueryParseResult(info.Env(), result);
 }
 
+Napi::String DeparseQuerySync(const Napi::CallbackInfo& info) {
+  std::string ast = info[0].As<Napi::String>();
+  auto protobufResult = json_to_protobuf_parse_result(ast);
+  PgQueryDeparseResult result;
+
+  if (protobufResult.error) {
+    result.query = (char*)malloc(0);
+    result.error = protobufResult.error;
+  } else {
+    result = pg_query_deparse_protobuf(protobufResult.protobuf);
+  }
+
+  return QueryDeparseResult(info.Env(), result);
+}
+
 Napi::String ParsePlPgSQLSync(const Napi::CallbackInfo& info) {
   std::string query = info[0].As<Napi::String>();
   PgQueryPlpgsqlParseResult result = pg_query_parse_plpgsql(query.c_str());

--- a/src/sync.h
+++ b/src/sync.h
@@ -1,5 +1,6 @@
 #include <napi.h>
 
 Napi::String ParseQuerySync(const Napi::CallbackInfo& info);
+Napi::String DeparseQuerySync(const Napi::CallbackInfo& info);
 Napi::String ParsePlPgSQLSync(const Napi::CallbackInfo& info);
 Napi::String FingerprintSync(const Napi::CallbackInfo& info);


### PR DESCRIPTION
Adds ability to deparse AST back into a SQL string.

### _We might not need this PR_
After starting work on this, I realized there was [this PR](https://github.com/launchql/libpg-query-node/pull/63) that already implements this. But since I took a different approach which may reduce bundle size, I thought I'd still open a PR. Might be worth picking some pieces from this PR if there's value.

## Background
Under the hood `libpg_query` supports both parsing and deparsing. It supports parsing SQL into JSON or protobuf, but it only supports deparsing from protobuf, not JSON. `libpg-query-node` uses the JSON approach for parsing, so this makes deparsing tricky. We need a way to first convert the AST to a protobuf, then pass into `libpg_query`'s deparse function.

## What this approach does differently
This approach does the JSON -> protobuf conversion in C++ vs JS. It uses the [protobuf C++ lib](https://github.com/protocolbuffers/protobuf) to convert the JSON AST to a profobuf directly in C++ before passing to deparse.

`libpg_query` actually comes with a protobuf generated C++ file, so no pre-processing step was required to compile the `.proto` file to another language.

## Affect on output size
`queryparser.node` went from ~2.8Mb to ~5.9Mb (macOS). This is more than double the size which is not ideal, but maybe still smaller than using a protobuf generated JS file. For my own use, the bigger concern would be the WASM file size increase, which I haven't got building yet (see below).

If we want the ability to deparse though, I'm not sure there is any way around bringing in a big protobuf generated file, apart from manually implementing a JSON deparsing function and upstreaming to `libpg_query` (probably a lot of work?).

### Recommendation
Offer 2 variants - one with deparse included and one without so that those who don't care about deparsing can benefit from a smaller bundle size. This probably only applies to WASM.

## Any downsides?
The biggest challenge is the [protobuf C++ dependency](https://github.com/protocolbuffers/protobuf). People will need this lib available on their machines in order for these bindings to compile. We could clone the protobuf repo and build it ourselves via a script (like we do with `libpg_query`), but this is probably more complicated since it uses build tools like bazel. We could try to rely on prebuilt versions of protobuf targeting different platforms, but I haven't found a pre-built emscripten version of protobuf yet, so that's a blocker for WASM support.
