### PR TITLE
Directly write the license in package.json for license management tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "binary:publish": "AWS_PROFILE=supabase-dev node-pre-gyp publish"
   },
   "author": "Dan Lynch <pyramation@gmail.com> (http://github.com/pyramation)",
-  "license": "LICENSE IN LICENSE",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/launchql/libpg-query-node.git"


### PR DESCRIPTION
License management tools such as [License Finder](https://github.com/pivotal/LicenseFinder) mis-detect a license as "LICENSE IN LICENSE", so I would like to want the license to be written directly in package.json.

The npm site also has the license as "LICENSE IN LICENSE":

🔗 https://www.npmjs.com/package/libpg-query

<img width="381" alt="libpg-query on npm site" src="https://github.com/user-attachments/assets/3d0dd51b-0a60-46bb-bc6c-81b7e77e9750">
